### PR TITLE
Add function as fallback for redux devtools

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -4,7 +4,7 @@ import ReduxThunk from 'redux-thunk'
 
 
 
-const devTools = window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+const devTools = window.__REDUX_DEVTOOLS_EXTENSION__ ? window.__REDUX_DEVTOOLS_EXTENSION__() : f => f
 
 const enhancer = compose(
     applyMiddleware(ReduxThunk),


### PR DESCRIPTION
# What this pullrequest does:

- Redux devtools setup was making the app crash on computers / mobile phones where the devtools extenstion was not installed 
![photo_2019-03-07 17 36 14](https://user-images.githubusercontent.com/47144624/53972668-8bee5000-40ff-11e9-930c-51e3eb51d642.jpeg)

- Changes fallback option to an empty function in case redux devtools extension is not installed in the browser. 
